### PR TITLE
Bump jupyterlite to 0.4.0 and pin ipywidgets in notebooks

### DIFF
--- a/content/hyperspy.ipynb
+++ b/content/hyperspy.ipynb
@@ -15,7 +15,8 @@
       },
       "outputs": [],
       "source": [
-        "%pip install -q ipympl hyperspy[gui-jupyter]"
+        "%pip install ipywidgets==8.1.3\n",
+        "%pip install ipympl hyperspy[gui-jupyter]"
       ]
     },
     {

--- a/content/rosettasciio.ipynb
+++ b/content/rosettasciio.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -q rosettasciio"
+    "%pip install rosettasciio"
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 # Core modules (mandatory)
-jupyterlite-core==0.3.0
-jupyterlab~=4.1.6
-notebook~=7.1.2
+jupyterlite-core==0.4.0
+jupyterlab~=4.2.4
+notebook~=7.2.1
 
 # Python kernel (optional)
-jupyterlite-pyodide-kernel==0.3.1
+jupyterlite-pyodide-kernel==0.4.1
 
 # Python: ipywidget library for Jupyter notebooks (optional)
-ipywidgets>=8.1.1,<9
+ipywidgets>=8.1.3,<9
 
 # Python: interative Matplotlib library for Jupyter notebooks (optional)
 ipympl>=0.8.2


### PR DESCRIPTION
Pinning ipywidgets seems to be necessary currently in jupyterlite as it would be break at each new release of `widgetsnbextension` - see https://github.com/jupyterlite/jupyterlite/issues/1342#issuecomment-2188962328.